### PR TITLE
Fix a preview bug when all layers are invisible

### DIFF
--- a/lib/common/data/project/scene.dart
+++ b/lib/common/data/project/scene.dart
@@ -27,9 +27,12 @@ class Scene extends TimeSpan {
   /// Visible image at a given playhead position.
   CompositeImage imageAt(Duration playhead) {
     playhead = playhead.clamp(Duration.zero, duration);
-    return CompositeImage(
-      visibleLayers.map((layer) => layer.frameAt(playhead).image).toList(),
-    );
+    final imageLayers =
+        visibleLayers.map((layer) => layer.frameAt(playhead).image).toList();
+
+    return imageLayers.isNotEmpty
+        ? CompositeImage(imageLayers)
+        : CompositeImage.empty(width: frameWidth, height: frameHeight);
   }
 
   /// All unique frames in this scene.

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,4 +1,1 @@
-- Sync layers (for separating sketch/line/fill)
-- Add smaller brush sizes
-- Fix a bug where short strokes with slight blur disappear
-- Improve timeline zoom responsiveness
+- Fix a preview bug when all layers are invisible


### PR DESCRIPTION
Should fix https://console.firebase.google.com/u/0/project/mooltik-760af/crashlytics/app/android:com.kakimov.mooltik/issues/0406fe1af7d91d09a82badb227a6d6a2