### PR TITLE
Switch to alternative package

### DIFF
--- a/lib/editing/data/export/exporter_model.dart
+++ b/lib/editing/data/export/exporter_model.dart
@@ -7,7 +7,7 @@ import 'package:mooltik/editing/data/export/generators/generator.dart';
 import 'package:mooltik/editing/data/export/generators/images_archive_generator.dart';
 import 'package:mooltik/editing/data/export/save_video_to_gallery.dart';
 import 'package:mooltik/editing/data/export/generators/video_generator.dart';
-import 'package:open_file/open_file.dart';
+import 'package:open_file_safe/open_file_safe.dart';
 import 'package:path/path.dart' as p;
 
 import 'package:mooltik/common/data/project/sound_clip.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -359,13 +359,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
-  open_file:
+  open_file_safe:
     dependency: "direct main"
     description:
-      name: open_file
+      name: open_file_safe
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.1"
+    version: "3.2.3"
   path:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: Storyboard animation app.
 
 # The following line prevents the package from being accidentally published to
 # pub.dev using `pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 # The following defines the version and build number for your application.
 # A version number is three numbers separated by dots, like 1.2.43
@@ -18,12 +18,12 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.20.0
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  
+
   # State management:
   provider: ^5.0.0
   equatable: ^2.0.2
@@ -57,7 +57,7 @@ dependencies:
   # Export:
   flutter_ffmpeg: ^0.4.2
   gallery_saver: ^2.1.3
-  open_file: ^3.2.1
+  open_file_safe: ^3.2.3
   share_plus: ^2.1.4
   archive: ^3.1.2
 
@@ -72,10 +72,10 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  
+
   # Generate app icons:
   flutter_launcher_icons: ^0.9.0
-  
+
   # Async testing:
   fake_async: ^1.2.0
   clock: ^1.1.0
@@ -90,7 +90,6 @@ flutter_icons:
 
 # The following section is specific to Flutter.
 flutter:
-
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.


### PR DESCRIPTION
`open_file` uses `REQUEST_INSTALL_PACKAGES`, which is dangerous.

`open_file_safe` is a safe alternative without such permission and removed support for `.apk` files.
Which we do not need anyway, since we only want to open exported videos/images.